### PR TITLE
Support blob and form data, return headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,28 @@ if (response.status === 'OK') {
   // Work with the returned error data that you expect in your response
 }
 ```
-More examples will follow ...
+
+### Request blob data, read return headers
+```ts
+const response = await request<never, { errorCode: number }>({
+  url: 'https://myapi.com',
+  body: { name: 'Updated name of user' },
+  method: 'PUT',
+  jsonResponse: false, // Response will not be in JSON
+  timeout: 1000, // Only 1 second timeout
+  validStatusCodes: [201], // Only 201 indicates success
+  extraHeaders: [{ key: 'Secret', value: '2lknf3oihvls' }, { key: 'Accept', value: 'application/octet-stream' }],
+})
+if (response.status === 'OK') {
+  // Things went well 👍
+
+  // Useful for example for injecting img src with data from the response
+  console.log(URL.createObjectURL(response.data));
+  console.log(response.headers['content-type']);
+} else if (response.status === 'NETWORK_ERROR') {
+  // Handle network error
+} else {
+  // Work with the returned error data that you expect in your response
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -52,14 +52,11 @@ if (response.status === 'OK') {
 
 ### Request blob data, read return headers
 ```ts
-const response = await request<never, { errorCode: number }>({
+const response = await request<Blob, never>({
   url: 'https://myapi.com',
-  body: { name: 'Updated name of user' },
-  method: 'PUT',
+  method: 'POST',
   jsonResponse: false, // Response will not be in JSON
-  timeout: 1000, // Only 1 second timeout
-  validStatusCodes: [201], // Only 201 indicates success
-  extraHeaders: [{ key: 'Secret', value: '2lknf3oihvls' }, { key: 'Accept', value: 'application/octet-stream' }],
+  extraHeaders: [{ key: 'Accept', value: 'application/octet-stream' }],
 })
 if (response.status === 'OK') {
   // Things went well 👍

--- a/src/api.ts
+++ b/src/api.ts
@@ -185,8 +185,6 @@ export function request<Return, Error, Body>(
     .catch((err: NetworkError | Error) => {
       // The error is either a timeout ('TIMEOUT'), a network error or a JSON parsing error
       // For now we're only handling the timeout, and calling all others 'OTHER'
-      console.log(err);
-      console.log("----------------- 2");
       let networkError: NetworkError = err === "TIMEOUT" ? "TIMEOUT" : "OTHER";
       if (
         (err as any).hasOwnProperty("type") &&

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ interface IBaseResponse {
 
 interface ISuccessResponse<T> extends IBaseResponse {
   data: T;
+  headers?: Record<string, string>;
   status: "OK";
 }
 
@@ -131,6 +132,7 @@ export function request<Return, Error, Body>(
     }
   }
 
+  let responseHeaders: Record<string, string> = {};
   return Promise.race([
     fetch(url, params),
     // The promise below will never resolve
@@ -145,6 +147,7 @@ export function request<Return, Error, Body>(
     .then((res: unknown) => {
       // response will always be type 'Response'
       const response = res as Response;
+      response.headers.forEach((value, key) => responseHeaders[key] = value);
       statusCode = response.status;
       switch(headers["Accept"]) {
         case "application/octet-stream":
@@ -169,6 +172,7 @@ export function request<Return, Error, Body>(
         const response: ISuccessResponse<Return> = {
           statusCode,
           data: data as Return,
+          headers: responseHeaders, 
           status: "OK",
         };
         return response;

--- a/src/api.ts
+++ b/src/api.ts
@@ -146,13 +146,16 @@ export function request<Return, Error, Body>(
       // response will always be type 'Response'
       const response = res as Response;
       statusCode = response.status;
-      // TODO: consider using actual response Accept headers to decide on json vs others
-      if (jsonResponse) {
-        return response.json();
-      } else {
-        return response.text();
+      switch(headers["Accept"]) {
+        case "application/octet-stream":
+          return response.blob();
+        case "application/json":
+          return response.json();
+        case "multipart/form-data":
+          return response.formData();
+        default: 
+          return response.text();
       }
-      // TODO: consider using response.formData() as well?
     })
     .then((data: Return | Error) => {
       // Allow expecting something other than 200s
@@ -182,6 +185,8 @@ export function request<Return, Error, Body>(
     .catch((err: NetworkError | Error) => {
       // The error is either a timeout ('TIMEOUT'), a network error or a JSON parsing error
       // For now we're only handling the timeout, and calling all others 'OTHER'
+      console.log(err);
+      console.log("----------------- 2");
       let networkError: NetworkError = err === "TIMEOUT" ? "TIMEOUT" : "OTHER";
       if (
         (err as any).hasOwnProperty("type") &&


### PR DESCRIPTION
I needed to be able to receive blob data from the server, as the CAPI returns an image/jpeg `Content-Type` that otherwise couldn't be processed with `URL.createObjectURL(response.data)`.

In addition, a success response now returns a `Record<string, string>` of response headers. This is needed to be able to read the `dimension-shot-padding-data` header coming from CAPI.